### PR TITLE
(Not ready) Allow specified functions to ignore indent_align_args

### DIFF
--- a/indent/r.vim
+++ b/indent/r.vim
@@ -35,6 +35,9 @@ endif
 if ! exists("g:r_indent_op_pattern")
   let g:r_indent_op_pattern = '\(+\|-\|\*\|/\|=\|\~\|%\)$'
 endif
+if ! exists("g:r_indent_noalign_funcs")
+  let g:r_indent_noalign_funcs = '\(shinyUI\|shinyServer\|htmlOutput\|imageOutput\|outputOptions\|tableOutput\|textOutput\|verbatimTextOutput\|downloadButton\|Progress\|withProgress\|renderPlot\|renderText\|renderPrint\|renderDataTable\|renderImage\|renderTable\|renderUI\|downloadHandler\|reactivePlot\|reactivePrint\|reactiveTable\|reactiveText\|reactiveUI\|absolutePanel\|bootstrapPage\|column\|conditionalPanel\|fixedPage\|fluidPage\|headerPanel\|helpText\|icon\|mainPanel\|navbarPage\|navlistPanel\|pageWithSidebar\|sidebarLayout\|sidebarPanel\|tabPanel\|tabsetPanel\|titlePanel\|inputPanel\|flowLayout\|splitLayout\|verticalLayout\|wellPanel\|withMathJax\)'
+endif
 
 function s:RDelete_quotes(line)
   let i = 0
@@ -309,7 +312,11 @@ function GetRIndent()
       if &filetype == "rhelp"
         let ind = s:Get_last_paren_idx(line, '(', ')', pb)
       else
-        let ind = s:Get_last_paren_idx(getline(lnum), '(', ')', pb)
+        if line =~ g:r_indent_noalign_funcs
+          let ind = indent(lnum) + &sw
+        else
+          let ind = s:Get_last_paren_idx(getline(lnum), '(', ')', pb)
+        endif
       endif
       return ind
     endif
@@ -508,6 +515,10 @@ function GetRIndent()
       return ind
     endif
   endwhile
+
+  if pline =~ g:r_indent_noalign_funcs && g:r_indent_align_args
+    return pind + &sw
+  endif
 
   return ind
 

--- a/tests/indent_test.R
+++ b/tests/indent_test.R
@@ -573,6 +573,17 @@ flights %>%
     endop <- "END"
 x <- 0
 
+
+shinyServer(
+    function(input, output) {
+        output$distPlot <- renderPlot({
+            x <- faithful[, 2]
+            bins <- seq(min(x), max(x), length.out = input$bins + 1)
+
+            hist(x, breaks = bins, col = 'darkgray', border = 'white')
+        })
+    })
+
 ############################################################################
 ## indent/r.vim starts to make mistakes here
 
@@ -655,6 +666,23 @@ try <- function(expr, silent = FALSE) {
     class(f) <- c(if(ordered)"ordered", "factor")
     f
 }
+
+shinyUI(fluidPage(
+    titlePanel("Hello Shiny!"),
+
+    sidebarLayout(
+        sidebarPanel(
+            sliderInput("bins",
+                        "Number of bins:",
+                        min = 1,
+                        max = 50,
+                        value = 30)
+            ),
+            mainPanel(
+                plotOutput("distPlot")
+                )
+         )
+    ))
 
 flights %>%
     group <- by(year, month, day) %>%

--- a/tests/indent_test_noalign.R
+++ b/tests/indent_test_noalign.R
@@ -558,6 +558,35 @@ flights %>%
     endop <- "END"
 x <- 0
 
+
+shinyUI(
+    fluidPage(
+        titlePanel("Hello Shiny!"),
+
+        sidebarLayout(
+            sidebarPanel(
+                sliderInput("bins",
+                    "Number of bins:",
+                    min = 1,
+                    max = 50,
+                    value = 30)
+                ),
+            mainPanel(
+                plotOutput("distPlot")
+                )
+            )
+        ))
+
+shinyServer(
+    function(input, output) {
+        output$distPlot <- renderPlot({
+            x <- faithful[, 2]
+            bins <- seq(min(x), max(x), length.out = input$bins + 1)
+
+            hist(x, breaks = bins, col = 'darkgray', border = 'white')
+        })
+    })
+
 ############################################################################
 ## indent/r.vim starts to make mistakes here
 


### PR DESCRIPTION
This pull request is close, but not working completely right.

Most of the time, I want `g:r_indent_align_args = 1`, but there are some functions for which I don't want to align args.  For example, when using the `shiny` package we end up with many nested functions and it makes more sense to just indent by a &sw for these functions than to align with the opening `(`.

This pull request adds a new variable that is just a regex of function names (defaulted to functions in the shiny package) for which indent should act like align_args is set to 0.

Like I said, it's not working quite right yet.  I also know that you don't want to add more complexity to the indent files because they are quite complicated already.  I decided to push this up in case someone else may be interested in this functionality and can finalize this pull request before I am able.
