### PR TITLE
Reintroduce support for older vim versions

### DIFF
--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -26,7 +26,11 @@ if exists("b:current_syntax")
   finish
 endif
 
-syn iskeyword @,48-57,_,.
+if has("patch-7.4.1142")
+  syn iskeyword @,48-57,_,.
+else
+  setlocal iskeyword=@,48-57,_,.
+endif
 
 if exists("g:r_syntax_folding") && g:r_syntax_folding
   setlocal foldmethod=syntax


### PR DESCRIPTION
On Debian jessie (currently the stable version of Debian), the command
syn iskeyword is not known to vim. However, I would like to use current R syntax files on such a system.
