### PR TITLE
Several improvements

### DIFF
--- a/syntax/rmd.vim
+++ b/syntax/rmd.vim
@@ -59,9 +59,7 @@ syntax match rmdChunkDelim "^[ \t]*```$" contained
 syntax region rmdChunk start="^[ \t]*``` *{r.*}$" end="^[ \t]*```$" contains=@R,rmdChunkDelim keepend fold
 
 " also match and syntax highlight in-line R code
-syntax match rmdEndInline "`" contained
-syntax match rmdBeginInline "`r " contained
-syntax region rmdrInline start="`r "  end="`" contains=@R,rmdBeginInline,rmdEndInline containedin=yamlFlowString keepend
+syntax region rmdrInline matchgroup=rmdInlineDelim start="`r "  end="`" contains=@R containedin=yamlFlowString keepend
 
 " match slidify special marker
 syntax match rmdSlidifySpecial "\*\*\*"
@@ -94,8 +92,7 @@ syn sync match rmdSyncChunk grouphere rmdChunk "^[ \t]*``` *{r"
 
 hi def link rmdYamlBlockDelim Delim
 hi def link rmdChunkDelim Special
-hi def link rmdBeginInline Special
-hi def link rmdEndInline Special
+hi def link rmdInlineDelim Special
 hi def link rmdBlockQuote Comment
 hi def link rmdSlidifySpecial Special
 

--- a/syntax/rmd.vim
+++ b/syntax/rmd.vim
@@ -1,22 +1,26 @@
 " markdown Text with R statements
 " Language: markdown with R code chunks
 " Homepage: https://github.com/jalvesaq/R-Vim-runtime
-" Last Change: Sat Oct 22, 2016
+" Last Change: Mon Oct 24, 2016
 "
 " CONFIGURATION:
 "   To highlight chunk headers as R code, put in your vimrc (e.g. .config/nvim/init.vim):
 "   let rmd_syn_hl_chunk = 1
 "
+"   For highlighting pandoc extensions to markdown like citations and TeX and
+"   many other advanced features like folding of markdown sections, it is
+"   recommended to install the vim-pandoc filetype plugin as well as the
+"   vim-pandoc-syntax filetype plugin from https://github.com/vim-pandoc.
+"
 " TODO:
-"   - Define sections based on markdown headers to provide syntax folding
-"   - Provide highlighting for rmarkdown citations
 "   - Provide highlighting for rmarkdown parameters in yaml header
 
 if exists("b:current_syntax")
   finish
 endif
 
-" load all of pandoc info
+" load all of pandoc info, e.g. from
+" https://github.com/vim-pandoc/vim-pandoc-syntax
 runtime syntax/pandoc.vim
 if exists("b:current_syntax")
   let rmdIsPandoc = 1
@@ -27,16 +31,16 @@ else
   if exists("b:current_syntax")
     unlet b:current_syntax
   endif
-endif
 
-" load all of the yaml syntax highlighting rules into @yaml
-syntax include @yaml syntax/yaml.vim
-if exists("b:current_syntax")
-  unlet b:current_syntax
-endif
+  " load all of the yaml syntax highlighting rules into @yaml
+  syntax include @yaml syntax/yaml.vim
+  if exists("b:current_syntax")
+    unlet b:current_syntax
+  endif
 
-" highlight yaml block commonly used for front matter
-syntax region rmdYamlBlock matchgroup=rmdYamlBlockDelim start="^---" matchgroup=rmdYamlBlockDelim end="^---" contains=@yaml keepend fold
+  " highlight yaml block commonly used for front matter
+  syntax region rmdYamlBlock matchgroup=rmdYamlBlockDelim start="^---" matchgroup=rmdYamlBlockDelim end="^---" contains=@yaml keepend fold
+endif
 
 " load all of the r syntax highlighting rules into @R
 syntax include @R syntax/r.vim

--- a/syntax/rmd.vim
+++ b/syntax/rmd.vim
@@ -59,7 +59,10 @@ syntax match rmdChunkDelim "^[ \t]*```$" contained
 syntax region rmdChunk start="^[ \t]*``` *{r.*}$" end="^[ \t]*```$" contains=@R,rmdChunkDelim keepend fold
 
 " also match and syntax highlight in-line R code
-syntax region rmdrInline matchgroup=rmdInlineDelim start="`r "  end="`" contains=@R containedin=yamlFlowString keepend
+syntax region rmdrInline matchgroup=rmdInlineDelim start="`r "  end="`" contains=@R containedin=pandocLaTeXRegion,yamlFlowString keepend
+" I was not able to highlight rmdrInline inside a pandocLaTeXCommand, although
+" highlighting works within pandocLaTeXRegion and yamlFlowString. 
+syntax cluster texMathZoneGroup add=rmdrInline
 
 " match slidify special marker
 syntax match rmdSlidifySpecial "\*\*\*"
@@ -72,8 +75,6 @@ if rmdIsPandoc == 0
   if exists("b:current_syntax")
     unlet b:current_syntax
   endif
-  " Extend cluster
-  syn cluster texMathZoneGroup add=rmdrInline
   " Inline
   syntax match rmdLaTeXInlDelim "\$"
   syntax match rmdLaTeXInlDelim "\\\$"


### PR DESCRIPTION
- Mention source of vim-pandoc and vim-pandoc syntax
- Only load yaml if pandoc is not taking care of that
- Simplify syntax for highlighting inline R code
- Highlight inline R code also in yaml and TeX regions (but in TeX commands it does not work)
