### PR TITLE
Improve roxygen highlighting

### DIFF
--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -72,10 +72,10 @@ if g:r_hl_roxygen
   syn region rOBlock start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @\(@\)\@!" end="^\s*\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
 
   " If a block contains an @rdname, @describeIn tag, it may have paragraph breaks, but does not have a title
-  syn region rOBlockNoTitle start="\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @rdname" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
-  syn region rOBlockNoTitle start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @rdname" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
-  syn region rOBlockNoTitle start="\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @describeIn" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
-  syn region rOBlockNoTitle start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @describeIn" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
+  syn region rOBlockNoTitle start="\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @rdname" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
+  syn region rOBlockNoTitle start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @rdname" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
+  syn region rOBlockNoTitle start="\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @describeIn" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
+  syn region rOBlockNoTitle start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @describeIn" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
 
   " A title as part of a block is always at the beginning of the block, i.e.
   " either at the start of a file or after a completely empty line.

--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -71,8 +71,14 @@ if g:r_hl_roxygen
   syn region rOBlock start="\%^\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @\(@\)\@!" end="^\s*\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
   syn region rOBlock start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @\(@\)\@!" end="^\s*\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
 
+  " If a block contains an @rdname, @describeIn tag, it may have paragraph breaks, but does not have a title
+  syn region rOBlockNoTitle start="\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @rdname" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
+  syn region rOBlockNoTitle start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @rdname" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
+  syn region rOBlockNoTitle start="\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @describeIn" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
+  syn region rOBlockNoTitle start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @describeIn" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
+
   " A title as part of a block is always at the beginning of the block, i.e.
-  " either at the start of a file or after a completely empty line
+  " either at the start of a file or after a completely empty line.
   syn match rOTitle "\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" contained contains=rOCommentKey,rOTitleTag
   syn match rOTitle "^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" contained contains=rOCommentKey,rOTitleTag
   syn match rOTitleTag contained "@title"
@@ -332,7 +338,8 @@ if g:r_hl_roxygen
   hi def link rOTitleTag   Operator
   hi def link rOTag        Operator
   hi def link rOTitleBlock Title
-  hi def link rOBlock        Comment
+  hi def link rOBlock         Comment
+  hi def link rOBlockNoTitle  Comment
   hi def link rOTitle      Title
   hi def link rOCommentKey Comment
   hi def link rOExamples   SpecialComment

--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -47,19 +47,38 @@ syn match rComment contains=@Spell,rCommentTodo,rOBlock "#.*"
 
 " Roxygen
 if g:r_hl_roxygen
-  syn region rOBlock start="^\s*\n#\{1,2}' " start="\%^#\{1,2}' " end="^\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
-  syn region rOTitle start="^\s*\n#\{1,2}' " start="\%^#\{1,2}' " end="^\(#\{1,2}'\s*$\)\@=" contained contains=rOCommentKey,rOTitleTag
+  " A roxygen block can start at the beginning of a file (first version) and
+  " after a blank line (second version). It ends when a line does not contain
+  " a roxygen comment
+  "
+  " When a roxygen block has a title, there are one or more lines (as little
+  " as possible are matched) starting with a roxygen comment, followed by a
+  " line with nothing but a roxygen comment and whitespace.
+  syn region rOBlock start="\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" end="^\s*\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
+  syn region rOBlock start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" end="^\s*\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
+
+  " A roxygen block containing the @rdname tag does not have to have a title
+  " and therefore does not have to have an empty roxygen comment line. This is
+  " therefore an alternative way to define a valid roxygen block often seen
+  " in practice, compare https://github.com/jalvesaq/Nvim-R/issues/84
+  syn region rOBlock start="\%^\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @rdname" end="^\s*\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
+  syn region rOBlock start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @rdname" end="^\s*\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
+
+  " Title at beginning of file (first version) or after an empty line (second
+  " version)
+  syn match rOTitle "\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" contained contains=rOCommentKey,rOTitleTag
+  syn match rOTitle "^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" contained contains=rOCommentKey,rOTitleTag
   syn match rOCommentKey "#\{1,2}'" containedin=rOTitle contained
 
   syn region rOExamples start="^#\{1,2}' @examples.*"rs=e+1,hs=e+1 end="^\(#\{1,2}' @.*\)\@=" end="^\(#\{1,2}'\)\@!" contained contains=rOTag fold
 
   syn match rOTitleTag contained "@title"
 
-  " rOTag list generated from the lists in 
-  " https://github.com/klutometis/roxygen/R/rd.R and 
+  " rOTag list generated from the lists in
+  " https://github.com/klutometis/roxygen/R/rd.R and
   " https://github.com/klutometis/roxygen/R/namespace.R
   " using s/^    \([A-Za-z0-9]*\) = .*/  syn match rOTag contained "@\1"/
-  
+
   " rd.R
   syn match rOTag contained "@aliases"
   syn match rOTag contained "@author"

--- a/tests/highlight_roxygen.R
+++ b/tests/highlight_roxygen.R
@@ -81,3 +81,10 @@ foobar.numeric <- function(x) abs(mean(x) - median(x))
 
 #' @describeIn foobar First and last values pasted together in a string.
 foobar.character <- function(x) paste0(x[1], "-", x[length(x)])
+
+#' A description that contains a newline as a paragraph break.
+#'
+#' The above is \emph{not} a title because the Roxygen block contains an
+#' \code{@rdname} designation.
+#' @rdname arguments
+paragraph_break = function () {}

--- a/tests/highlight_roxygen.R
+++ b/tests/highlight_roxygen.R
@@ -1,6 +1,3 @@
-# Test file for roxygen syntax
-# Authors: Johannes Ranke, Konrad Rudolph and others (see comments).
-
 #' Title at the beginning of the file
 #'
 #' This is the description.
@@ -16,6 +13,9 @@ foo = function() {
   x <- 3
   return(x)
 }
+
+# This is a test file for roxygen syntax
+# Authors: Johannes Ranke, Konrad Rudolph and others (see comments).
 
 #' A title after some whitespace
 #'
@@ -46,19 +46,19 @@ lessbar = function() …
 lessbar_ = function() …
 
 #' A function with just a title, nothing else.
-small_function = function () TRUE
+small_function = function() TRUE
 
 #' A function with just a title, containing, a literal at sign
 #' @@ the beginning of the second line as a special case
-small_function = function () TRUE
+small_function = function() TRUE
 
 #' Another small function, but exported. If there is no empty roxygen line
 #' after this text, it is not recognized as a title, although roxygen will
 #' treat it as a title if there is no @rdname or @describeIn tag.
 #' @export
-small_function = function () TRUE
+small_function = function() TRUE
 
-# The following roxygen code was taken from the documentation
+# The following roxygen block was taken from the documentation
 # of roxygen::collate_roclet().
 
 #' `example-a.R', `example-b.R' and `example-c.R' reside
@@ -87,4 +87,4 @@ foobar.character <- function(x) paste0(x[1], "-", x[length(x)])
 #' The above is \emph{not} a title because the Roxygen block contains an
 #' \code{@rdname} designation.
 #' @rdname arguments
-paragraph_break = function () {}
+paragraph_break = function() {}

--- a/tests/highlight_roxygen.R
+++ b/tests/highlight_roxygen.R
@@ -46,21 +46,5 @@ lessbar_ = function() …
 #' markup, and is therefore just highlighted as a comment.
 x <- x
 
-#' This is a title of a Roxygen block without following newline
-#' @param foo this describes parameter foo
-#'
-#' Description
-f = function (foo) f
-
-#' Title
-#' @details Likewise, this is no longer part of the title.
-#'
-#' More description. Weird Roxygen layout, but legal.
-g = function () f
-
 #' A function with just a title, nothing else.
 small_function = function () TRUE
-
-#' Another function with a title
-#' @details The function's description. No longer title.
-another_small_function = function () FALSE

--- a/tests/highlight_roxygen.R
+++ b/tests/highlight_roxygen.R
@@ -86,5 +86,6 @@ foobar.character <- function(x) paste0(x[1], "-", x[length(x)])
 #'
 #' The above is \emph{not} a title because the Roxygen block contains an
 #' \code{@rdname} designation.
+#'
 #' @rdname arguments
 paragraph_break = function() {}

--- a/tests/highlight_roxygen.R
+++ b/tests/highlight_roxygen.R
@@ -1,3 +1,6 @@
+# Test file for roxygen syntax
+# Authors: Johannes Ranke, Konrad Rudolph and others (see comments).
+
 #' Title at the beginning of the file
 #'
 #' This is the description.
@@ -29,8 +32,8 @@ bar = function() …
 morebar = function() …
 
 #' \code{lessbar} works somehow like \code{morebar} but differently
-#' and with an additional parameter x. As this goes into the 
-#' documentation of \code{morebar} due to the rdname tag, this 
+#' and with an additional parameter x. As this goes into the
+#' documentation of \code{morebar} due to the rdname tag, this
 #' block does not have a title.
 #' @param x Another parameter
 #' @rdname morebar
@@ -42,9 +45,39 @@ lessbar = function() …
 #' @export
 lessbar_ = function() …
 
-#' This is marked as a roxygen block but does not contain any further roxygen
-#' markup, and is therefore just highlighted as a comment.
-x <- x
-
 #' A function with just a title, nothing else.
 small_function = function () TRUE
+
+#' A function with just a title, containing, a literal at sign
+#' @@ the beginning of the second line as a special case
+small_function = function () TRUE
+
+#' Another small function, but exported. If there is no empty roxygen line
+#' after this text, it is not recognized as a title, although roxygen will
+#' treat it as a title if there is no @rdname or @describeIn tag.
+#' @export
+small_function = function () TRUE
+
+# The following roxygen code was taken from the documentation
+# of roxygen::collate_roclet().
+
+#' `example-a.R', `example-b.R' and `example-c.R' reside
+#' in the `example' directory, with dependencies
+#' a -> {b, c}. This is `example-a.R'.
+#' @include example-b.R
+#' @include example-c.R
+NULL
+
+# The following example is from the roxygen vignette
+# https://cran.r-project.org/web/packages/roxygen2/vignettes/rd.html
+
+#' Foo bar generic
+#'
+#' @param x Object to foo.
+foobar <- function(x) UseMethod("x")
+
+#' @describeIn foobar Difference between the mean and the median
+foobar.numeric <- function(x) abs(mean(x) - median(x))
+
+#' @describeIn foobar First and last values pasted together in a string.
+foobar.character <- function(x) paste0(x[1], "-", x[length(x)])

--- a/tests/highlight_roxygen.R
+++ b/tests/highlight_roxygen.R
@@ -1,0 +1,47 @@
+#' Title at the beginning of the file
+#'
+#' This is the description.
+#'
+#' This would go to details.
+#'
+#' @param test hallo
+#' @export
+#' @examples
+#' # Example code is highlighted as a special comment
+#' d <- data.frame(a = 1:3, b = "b")
+foo = function() {
+  x <- 3
+  return(x)
+}
+
+#' A title after some whitespace
+#'
+#' Another description
+bar = function() …
+
+#' This is a title containing a
+#' line break
+#'
+#' The description of morebar.
+#'
+#' @param test
+#' @export
+morebar = function() …
+
+#' \code{lessbar} works somehow like \code{morebar} but differently
+#' and with an additional parameter x. As this goes into the 
+#' documentation of \code{morebar} due to the rdname tag, this 
+#' block does not have a title.
+#' @param x Another parameter
+#' @rdname morebar
+#' @export
+lessbar = function() …
+
+#' @rdname morebar
+#' @details \code{lessbar_} is yet a bit different, but also useful.
+#' @export
+lessbar_ = function() …
+
+#' This is marked as a roxygen block but does not contain any further roxygen
+#' markup, and is therefore just highlighted as a comment.
+x <- x

--- a/tests/highlight_roxygen.R
+++ b/tests/highlight_roxygen.R
@@ -45,3 +45,22 @@ lessbar_ = function() …
 #' This is marked as a roxygen block but does not contain any further roxygen
 #' markup, and is therefore just highlighted as a comment.
 x <- x
+
+#' This is a title of a Roxygen block without following newline
+#' @param foo this describes parameter foo
+#'
+#' Description
+f = function (foo) f
+
+#' Title
+#' @details Likewise, this is no longer part of the title.
+#'
+#' More description. Weird Roxygen layout, but legal.
+g = function () f
+
+#' A function with just a title, nothing else.
+small_function = function () TRUE
+
+#' Another function with a title
+#' @details The function's description. No longer title.
+another_small_function = function () FALSE


### PR DESCRIPTION
Following the discussion in jalvesaq/Nvim-R#84
- Add support for titles spanning more than one row
- Add support for roxygen blocks without a title, as this can make sense
  when an @rdname tag is present
- If no title is recognised, and no @rdname is present, just highlight
  as R comment section