### PR TITLE
fix #28

### DIFF
--- a/indent/rnoweb.vim
+++ b/indent/rnoweb.vim
@@ -21,7 +21,7 @@ else
   let s:TeXIndent = function(substitute(&indentexpr, "()", "", ""))
 endif
 
-unlet b:did_indent
+unlet! b:did_indent
 runtime indent/r.vim
 let s:RIndent = function(substitute(&indentexpr, "()", "", ""))
 let b:did_indent = 1


### PR DESCRIPTION
Instead of throwing an error, removing `b:did_indent` is removed silently if it doesn't exist. This is consistent with the usage in other file types, such as eruby.vim