### PR TITLE
unmask rOBlock syntax

### DIFF
--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -71,6 +71,12 @@ if g:r_syntax_hl_roxygen
   syn match rOTitleBlock "\%^\(\s*#\{1,2}' .*\n\)\{1,}" contains=rOCommentKey,rOTitleTag
   syn match rOTitleBlock "^\s*\n\(\s*#\{1,2}' .*\n\)\{1,}" contains=rOCommentKey,rOTitleTag
 
+  " A title as part of a block is always at the beginning of the block, i.e.
+  " either at the start of a file or after a completely empty line.
+  syn match rOTitle "\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" contained contains=rOCommentKey,rOTitleTag
+  syn match rOTitle "^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" contained contains=rOCommentKey,rOTitleTag
+  syn match rOTitleTag contained "@title"
+
   " When a roxygen block has a title and additional content, the title
   " consists of one or more roxygen lines (as little as possible are matched),
   " followed either by an empty roxygen line
@@ -86,12 +92,6 @@ if g:r_syntax_hl_roxygen
   syn region rOBlockNoTitle start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @rdname" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
   syn region rOBlockNoTitle start="\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @describeIn" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
   syn region rOBlockNoTitle start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @describeIn" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
-
-  " A title as part of a block is always at the beginning of the block, i.e.
-  " either at the start of a file or after a completely empty line.
-  syn match rOTitle "\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" contained contains=rOCommentKey,rOTitleTag
-  syn match rOTitle "^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" contained contains=rOCommentKey,rOTitleTag
-  syn match rOTitleTag contained "@title"
 
   syn match rOCommentKey "^\s*#\{1,2}'" contained
   syn region rOExamples start="^#\{1,2}' @examples.*"rs=e+1,hs=e+1 end="^\(#\{1,2}' @.*\)\@=" end="^\(#\{1,2}'\)\@!" contained contains=rOTag fold


### PR DESCRIPTION
Sometimes, syn region rOBlock is masked by syn match rOTitle.
Moving rOTitle syntax declarations before rOBlock fixes the issue.

Here is a minimal example:

Open vim and run

```
:let g:r_syntax_folding=1
:set ft=r
```

Insert the following code snippet:
```
# section ####

#' rotitle
#'
#' description
#'
#' @param foo
#' @param bar
```

Prior to this commit, the roxygen block after `rotitle` is not highlighted correctly. `@param`s are not highlighted as roxygen tags.
Also, with the cursor on `#'` before `description`, 
`echo synstack(line('.'), col('.'))->reverse()->map("synIDattr(v:val,'name')")` gives
`['rOCommentKey', 'rOTitle', 'rSection']`

With this commit, the roxygen block and `@param`s are highlighted correctly.
With the cursor on `#'` before `description`, 
`echo synstack(line('.'), col('.'))->reverse()->map("synIDattr(v:val,'name')")` gives
`['rOCommentKey', 'rOTitle', 'rOBlock', 'rSection']`

