### PR TITLE
don't warn about `[` missing a matching ]

### DIFF
--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -257,12 +257,12 @@ syn match rDelimiter "[,;:]"
 if exists("g:r_syntax_folding")
   syn region rRegion matchgroup=Delimiter start=/(/ matchgroup=Delimiter end=/)/ transparent contains=ALLBUT,rError,rBraceError,rCurlyError fold
   syn region rRegion matchgroup=Delimiter start=/{/ matchgroup=Delimiter end=/}/ transparent contains=ALLBUT,rError,rBraceError,rParenError fold
-  syn region rRegion matchgroup=Delimiter start=/\[/ matchgroup=Delimiter end=/]/ transparent contains=ALLBUT,rError,rCurlyError,rParenError fold
+  syn region rRegion matchgroup=Delimiter start=/\(`\)\@!\[/ matchgroup=Delimiter end=/]/ transparent contains=ALLBUT,rError,rCurlyError,rParenError fold
   syn region rSection matchgroup=Title start=/^#.*[-=#]\{4,}/ end=/^#.*[-=#]\{4,}/ms=s-2,me=s-1 transparent contains=ALL fold
 else
   syn region rRegion matchgroup=Delimiter start=/(/ matchgroup=Delimiter end=/)/ transparent contains=ALLBUT,rError,rBraceError,rCurlyError
   syn region rRegion matchgroup=Delimiter start=/{/ matchgroup=Delimiter end=/}/ transparent contains=ALLBUT,rError,rBraceError,rParenError
-  syn region rRegion matchgroup=Delimiter start=/\[/ matchgroup=Delimiter end=/]/ transparent contains=ALLBUT,rError,rCurlyError,rParenError
+  syn region rRegion matchgroup=Delimiter start=/\(`\)\@!\[/ matchgroup=Delimiter end=/]/ transparent contains=ALLBUT,rError,rCurlyError,rParenError
 endif
 
 syn match rError      "[)\]}]"


### PR DESCRIPTION
Code like this doesn't need a matching `]`:

    map_chr( `[`(2))

My change won't warn about this:

```r
(
[
)
```
But I think nobody puts `[` at the start of the line.