### PR TITLE
Basic highlighting of roxygen in R6 classes

### DIFF
--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -58,7 +58,7 @@ syn match rComment contains=@Spell,rCommentTodo,rTodoParen,rOBlock "#.*"
 " Roxygen
 if g:r_syntax_hl_roxygen
   " A roxygen block can start at the beginning of a file (first version) and
-  " after a blank line (second version). It ends when a line that does not
+  " after a blank line (second version). It ends when a line appears that does not
   " contain a roxygen comment. In the following comments, any line containing
   " a roxygen comment marker (one or two hash signs # followed by a single
   " quote ' and preceded only by whitespace) is called a roxygen line. A
@@ -96,7 +96,7 @@ if g:r_syntax_hl_roxygen
   syn match rOCommentKey "^\s*#\{1,2}'" contained
   syn region rOExamples start="^#\{1,2}' @examples.*"rs=e+1,hs=e+1 end="^\(#\{1,2}' @.*\)\@=" end="^\(#\{1,2}'\)\@!" contained contains=rOTag fold
 
-  " rOTag list generated from the lists in
+  " rOTag list originally generated from the lists that were available in
   " https://github.com/klutometis/roxygen/R/rd.R and
   " https://github.com/klutometis/roxygen/R/namespace.R
   " using s/^    \([A-Za-z0-9]*\) = .*/  syn match rOTag contained "@\1"/

--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -155,7 +155,10 @@ if g:r_syntax_hl_roxygen
   syn match rOTag contained "@S3method"
   syn match rOTag contained "@useDynLib"
   " other
+  syn match rOTag contained "@eval"
   syn match rOTag contained "@include"
+  syn match rOTag contained "@includeRmd"
+  syn match rOTag contained "@order"
 endif
 
 

--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -53,7 +53,7 @@ syn match rCommentTodo contained "\(BUG\|FIXME\|NOTE\|TODO\):"
 syn match rTodoParen contained "\(BUG\|FIXME\|NOTE\|TODO\)\s*(.\{-})\s*:" contains=rTodoKeyw,rTodoInfo transparent
 syn keyword rTodoKeyw BUG FIXME NOTE TODO contained
 syn match rTodoInfo "(\zs.\{-}\ze)" contained
-syn match rComment contains=@Spell,rCommentTodo,rTodoParen,rOBlock "#.*"
+syn match rComment contains=@Spell,rCommentTodo,rTodoParen "#.*"
 
 " Roxygen
 if g:r_syntax_hl_roxygen
@@ -94,7 +94,12 @@ if g:r_syntax_hl_roxygen
   syn region rOBlockNoTitle start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @describeIn" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
 
   syn match rOCommentKey "^\s*#\{1,2}'" contained
-  syn region rOExamples start="^#\{1,2}' @examples.*"rs=e+1,hs=e+1 end="^\(#\{1,2}' @.*\)\@=" end="^\(#\{1,2}'\)\@!" contained contains=rOTag fold
+  syn region rOExamples start="^\s*#\{1,2}' @examples.*"rs=e+1,hs=e+1 end="^\(#\{1,2}' @.*\)\@=" end="^\(#\{1,2}'\)\@!" contained contains=rOTag fold
+
+  " R6 classes may contain roxygen lines independent of roxygen blocks
+  syn region rOR6Class start=/R6Class(/ end=/)/ transparent contains=ALLBUT,rError,rBraceError,rCurlyError fold
+  syn match rOR6Block "#\{1,2}'.*" contains=rOTag,rOExamples,@Spell containedin=rOR6Class contained
+  syn match rOR6Block "^\s*#\{1,2}'.*" contains=rOTag,rOExamples,@Spell containedin=rOR6Class contained
 
   " rOTag list originally generated from the lists that were available in
   " https://github.com/klutometis/roxygen/R/rd.R and
@@ -369,6 +374,7 @@ if g:r_syntax_hl_roxygen
   hi def link rOTitleBlock Title
   hi def link rOBlock         Comment
   hi def link rOBlockNoTitle  Comment
+  hi def link rOR6Block         Comment
   hi def link rOTitle      Title
   hi def link rOCommentKey Comment
   hi def link rOExamples   SpecialComment

--- a/tests/highlight_roxygen.R
+++ b/tests/highlight_roxygen.R
@@ -89,3 +89,55 @@ foobar.character <- function(x) paste0(x[1], "-", x[length(x)])
 #'
 #' @rdname arguments
 paragraph_break = function() {}
+
+# The following example is from the roxygen documentation at
+# https://roxygen2.r-lib.org/articles/rd.html#r6
+# which in turn got it from the R6 tutorial
+
+#' R6 Class Representing a Person
+#'
+#' @description
+#' A person has a name and a hair color.
+#'
+#' @details
+#' A person can also greet you.
+
+Person <- R6::R6Class("Person",
+public = list(
+
+    #' @field name First or full name of the person.
+    name = NULL,
+
+    #' @field hair Hair color of the person.
+    hair = NULL,
+
+    #' @description
+    #' Create a new person object.
+    #' @param name Name.
+    #' @param hair Hair color.
+    #' @return A new `Person` object.
+    initialize = function(name = NA, hair = NA) {
+      self$name <- name
+      self$hair <- hair
+      self$greet()
+    },
+
+    #' @description
+    #' Change hair color.
+    #' @param val New hair color.
+    #' @examples
+    #' P <- Person("Ann", "black")
+    #' P$hair
+    #' P$set_hair("red")
+    #' P$hair
+    set_hair = function(val) {
+      self$hair <- val
+    },
+
+    #' @description
+    #' Say hi.
+    greet = function() {
+      cat(paste0("Hello, my name is ", self$name, ".\n"))
+    }
+  )
+)


### PR DESCRIPTION
I find working on the roxygen syntax rather difficult. Maybe someone has a fresh approach to it and would like to rewrite this, I have to admit that I do not understand why some of the lines I am introducing are necessary. 
Note that inline example code for methods is not highlighted as other roxygen example code. Anyways, it is better than not to have highlighting of roxygen markup in R6 classes at all. Regarding example code, I personally prefer to collect example code in the roxygen block before the class definition starts.

Closes #36.