### PR TITLE
Add syntax/indent support for native pipe

### DIFF
--- a/indent/r.vim
+++ b/indent/r.vim
@@ -30,7 +30,7 @@ let g:r_indent_ess_comments   = get(g:, 'r_indent_ess_comments',    0)
 let g:r_indent_comment_column = get(g:, 'r_indent_comment_column', 40)
 let g:r_indent_ess_compatible = get(g:, 'r_indent_ess_compatible',  0)
 let g:r_indent_op_pattern     = get(g:, 'r_indent_op_pattern',
-      \ '\(&\||\|+\|-\|\*\|/\|=\|\~\|%\|->\)\s*$')
+      \ '\(&\||\|+\|-\|\*\|/\|=\|\~\|%\|->\||>\)\s*$')
 
 function s:RDelete_quotes(line)
   let i = 0

--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -247,6 +247,7 @@ endif
 syn match rOperator    "%\{2}\|%\S\{-}%"
 syn match rOperator '\([!><]\)\@<=='
 syn match rOperator '=='
+syn match rOperator '|>'
 syn match rOpError  '\*\{3}'
 syn match rOpError  '//'
 syn match rOpError  '&&&'


### PR DESCRIPTION
Add support for the native pipe operator `|>` introduced in [R 4.10](https://developer.r-project.org/blosxom.cgi/R-devel/NEWS/2020/12/04#n2020-12-04).