### PR TITLE
Recognise anonymous function shorthand (backslash) as rType

### DIFF
--- a/syntax/r.vim
+++ b/syntax/r.vim
@@ -313,6 +313,7 @@ if &filetype == "rhelp"
 endif
 
 " Type
+syn match rType "\\"
 syn keyword rType array category character complex double function integer list logical matrix numeric vector data.frame
 
 " Name of object with spaces


### PR DESCRIPTION
I would like the net (R4.1.0) anonymous function shorthand (`\`) to be highlighted correctly.  This fix shouldn't mess up the string highlighting.

Previously:
![Screenshot 2023-02-24 at 23 26 58](https://user-images.githubusercontent.com/46621136/221218001-8a00ee57-c328-4837-9df8-afd109354878.png)

Now:
![Screenshot 2023-02-24 at 23 26 21](https://user-images.githubusercontent.com/46621136/221217828-5e52c10e-92d5-4de6-b600-3d0e521385e6.png)